### PR TITLE
Add a page that lists the framework versions that we found

### DIFF
--- a/src/Listener.php
+++ b/src/Listener.php
@@ -18,6 +18,7 @@ class Listener extends PluginListener
         $event->addRoute('/^sites\/(?P<site_id>(\d*))\/unl_progress\/edit\/$/', __NAMESPACE__ . '\Progress\EditForm');
         $event->addRoute('/^unl_progress\/4x0\/$/', __NAMESPACE__ . '\Progress4x0');
         $event->addRoute('/^unl_progress\/help\/4.0_progress\/$/', __NAMESPACE__ . '\Help\Progress4x0');
+        $event->addRoute('/^sites\/(?P<site_id>(\d*))\/scans\/(?P<scans_id>(\d*))\/unl\/versions\/$/',     __NAMESPACE__ . '\Scan\FrameworkVersions');
     }
 
     /**

--- a/src/Progress/Summary.php
+++ b/src/Progress/Summary.php
@@ -30,6 +30,11 @@ class Summary
      */
     public $scan_attributes = false;
 
+    /**
+     * @var bool|\SiteMaster\Core\Auditor\Scan
+     */
+    public $scan = false;
+
     function __construct($options = array())
     {
         $this->options += $options;
@@ -47,8 +52,8 @@ class Summary
             $this->progress = Progress::createNewProgress($this->site->id);
         }
         
-        if ($scan = $this->site->getLatestScan()) {
-            $this->scan_attributes = ScanAttributes::getByScansID($scan->id);
+        if ($this->scan = $this->site->getLatestScan()) {
+            $this->scan_attributes = ScanAttributes::getByScansID($this->scan->id);
         }
     }
 

--- a/src/Scan/FrameworkVersions.php
+++ b/src/Scan/FrameworkVersions.php
@@ -1,0 +1,58 @@
+<?php
+namespace SiteMaster\Plugins\Unl\Scan;
+
+use SiteMaster\Core\Auditor\Scan;
+use SiteMaster\Core\Auditor\Site\Pages\AllForScan;
+use SiteMaster\Core\InvalidArgumentException;
+use SiteMaster\Core\ViewableInterface;
+
+class FrameworkVersions implements ViewableInterface
+{
+    /**
+     * @var array
+     */
+    public $options = array();
+
+    /**
+     * @var array
+     */
+    public $all_pages = array();
+
+    /**
+     * @var bool|\SiteMaster\Core\Auditor\Scan
+     */
+    public $scan = false;
+
+    function __construct($options = array())
+    {
+        $this->options += $options;
+
+        //get the site
+        if (isset($this->options['scan'])) {
+            $this->scan = $this->options['scan'];
+        } else {
+            //Try to get it by ID
+            if (!isset($this->options['scans_id'])) {
+                throw new InvalidArgumentException('a scan id is required', 400);
+            }
+
+            if (!$this->scan = Scan::getByID($this->options['scans_id'])) {
+                throw new InvalidArgumentException('Could not find a scan for the given page.', 500);
+            }
+        }
+        
+        $this->all_pages = new AllForScan(array(
+            'scans_id' => $this->scan->id
+        ));
+    }
+
+    public function getURL()
+    {
+        return $this->scan->getURL() . 'unl/versions/';
+    }
+
+    public function getPageTitle()
+    {
+        return 'Framework Versions';
+    }
+}

--- a/www/templates/html/Progress/Summary.tpl.php
+++ b/www/templates/html/Progress/Summary.tpl.php
@@ -51,9 +51,17 @@ if ($context->depIsValid()) {
                 <dt>Comments</dt>
                 <dd><?php echo $context->progress->self_comments ?></dd>
             </dl>
+        </div>
+        <div class="wdn-col-full wdn-center">
             <?php
+            if ($context->scan) {
+                ?>
+                <a href="<?php echo $context->scan->getURL() ?>unl/versions/" class="wdn-button wdn-button-triad">See what versions we found</a>
+            <?php
+            }
+    
             $user = \SiteMaster\Core\User\Session::getCurrentUser();
-
+    
             if ($user && $context->site->userIsVerified($user)) {
                 ?>
                 <a href="<?php echo $context->site->getURL() ?>unl_progress/edit/" class="wdn-button wdn-pull-right">Edit self reported progress</a>

--- a/www/templates/html/Scan/FrameworkVersions.tpl.php
+++ b/www/templates/html/Scan/FrameworkVersions.tpl.php
@@ -1,0 +1,54 @@
+<?php
+$scan           = $context->scan;
+$site           = $scan->getSite();
+?>
+
+<div class="framework-versions info-section">
+    <header>
+        <h3>UNLedu Framework Versions by Page</h3>
+        <div class="subhead">
+            This is a list of all framework versions that we found on your site.
+        </div>
+    </header>
+    <table data-sortlist="[[0,0],[2,0]]" class="sortable">
+        <thead>
+        <tr>
+            <th class="path">Path</th>
+            <th class="unl-html-version">UNLedu HTML Version</th>
+            <th class="unl-dep-version">UNLedu Dependents Version</th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php
+        foreach ($context->all_pages as $page) {
+            $attributes = \SiteMaster\Plugins\Unl\PageAttributes::getByScannedPageID($page->id);
+            ?>
+            <tr>
+                <td class="path">
+                    <a href="<?php echo $page->getURL()?>"><?php echo $theme_helper->trimBaseURL($site->base_url, $page->uri) ?></a>
+                </td>
+                <td class="unl-html-version">
+                    <?php
+                    $version = '';
+                    if ($attributes) {
+                        $version = $attributes->html_version;
+                    }
+                    echo $version;
+                    ?>
+                </td>
+                <td class="unl-dep-version">
+                    <?php
+                    $version = '';
+                    if ($attributes) {
+                        $version = $attributes->dep_version;
+                    }
+                    echo $version;
+                    ?>
+                </td>
+            </tr>
+        <?php
+        }
+        ?>
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
It can currently hard to tell which pages are out of date in a site.

For example, say x site is in 4.0.  However two pages in the site are still in 3.1.  Because 3.1 pages are still valid, they will not be marked under the UNLedu Framework metric, but the overall site framework version will be 3.1 (because it was the lowest version found).
