### PR TITLE
Track Version Uptake

### DIFF
--- a/data/database.sql
+++ b/data/database.sql
@@ -48,3 +48,13 @@ CREATE TABLE IF NOT EXISTS `unl_site_progress` (
   references `sites`(`id`),
   PRIMARY KEY  (`id`)
 ) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `unl_version_history` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `version_type` ENUM('HTML', 'DEP') NOT NULL,
+  `version_number` VARCHAR(56),
+  `number_of_sites` INT NOT NULL DEFAULT 0,
+  `date_created` DATE NOT NULL,
+  PRIMARY KEY  (`id`),
+  UNIQUE (`date_created`, `version_type`, `version_number`)
+) ENGINE = InnoDB;

--- a/data/database.sql
+++ b/data/database.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS `unl_scan_attributes` (
   `scans_id` INT NOT NULL,
   `html_version` VARCHAR(10),
   `dep_version` VARCHAR(10),
+  `root_site_url` VARCHAR(255),
   CONSTRAINT `fk_unl_scan_attributes_scans1`
   FOREIGN KEY (`scans_id`)
   REFERENCES `scans` (`id`)
@@ -36,10 +37,14 @@ CREATE TABLE IF NOT EXISTS `unl_site_progress` (
   `self_comments` TEXT,
   `created` DATETIME NOT NULL,
   `updated` DATETIME NOT NULL,
+  `replaced_by` INT NULL,
   CONSTRAINT `fk_unl_site_status_site1`
   FOREIGN KEY (`sites_id`)
   REFERENCES `sites` (`id`)
     ON DELETE CASCADE
     ON UPDATE NO ACTION,
+  CONSTRAINT fk_replaced_by
+  FOREIGN KEY (`replaced_by`)
+  references `sites`(`id`),
   PRIMARY KEY  (`id`)
 ) ENGINE = InnoDB;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -89,6 +89,14 @@ class Plugin extends PluginInterface
                 return false;
             }
         }
+
+        if ($previousVersion <= 2014063001) {
+            $sql = file_get_contents($this->getRootDirectory() . "/data/database.sql");
+
+            if (!Util::execMultiQuery($sql, true)) {
+                return false;
+            }
+        }
         
         return true;
     }
@@ -104,7 +112,7 @@ class Plugin extends PluginInterface
      */
     public function getVersion()
     {
-        return 2014063001;
+        return 2015010701;
     }
 
     /**

--- a/src/VersionHistory.php
+++ b/src/VersionHistory.php
@@ -1,0 +1,83 @@
+<?php
+namespace SiteMaster\Plugins\Unl;
+
+use DB\Record;
+use DB\RecordList;
+use SiteMaster\Core\Registry\Site\Member;
+use Sitemaster\Core\Util;
+
+class VersionHistory extends Record
+{
+    public $id; //int required
+    public $version_type; //ENUM('HTML', 'DEP')
+    public $version_number; //VARCHAR
+    public $number_of_sites; //INT
+    public $date_created; //DATETIME
+    
+    const VERSION_TYPE_HTML = 'HTML';
+    const VERSION_TYPE_DEP = 'DEP';
+
+    public function keys()
+    {
+        return array('id');
+    }
+
+    public static function getTable()
+    {
+        return 'unl_version_history';
+    }
+
+    /**
+     * Get a VersionHistory object
+     *
+     * @param int $id
+     * @return bool|VersionHistory
+     */
+    public static function getByID($id)
+    {
+        return self::getByAnyField(__CLASS__, 'id', $id);
+    }
+
+    /**
+     * Get a VersionHistory object
+     *
+     * @param $date
+     * @param $version_type
+     * @param $version
+     * @return bool|VersionHistory
+     */
+    public static function getByDateAndVersion($date, $version_type, $version)
+    {
+        return self::getByAnyField(
+            __CLASS__, 
+            'date_created',
+            $date,
+            'version_type = "' . RecordList::escapeString($version_type) . '" AND version_number = "' . RecordList::escapeString($version) . '"'
+        );
+    }
+
+    /**
+     * Create a new Version History Record
+     *
+     * @param $version_type
+     * @param $version_number
+     * @param $number_of_sites
+     * @param $date_created
+     * @return bool|ScanAttributes
+     */
+    public static function createHistoryRecord($version_type, $version_number, $number_of_sites, $date_created)
+    {
+        $record = new self();
+
+        $record->version_type = $version_type;
+        $record->version_number = $version_number;
+        $record->number_of_sites = $number_of_sites;
+        $record->date_created = $date_created;
+
+        if (!$record->insert()) {
+            return false;
+        }
+
+        return $record;
+    }
+}


### PR DESCRIPTION
This adds a db table and script to store aggregate data on UNLedu Framework Version up adoption rates. The idea being that this data can eventually be used to help guide our efforts when releasing new versions. We could even add a chart to help visualize this data eventually.