### PR TITLE
WIP: Enforce a11y practices for wdn-icon-* classes

### DIFF
--- a/src/Metric.php
+++ b/src/Metric.php
@@ -525,7 +525,7 @@ class Metric extends MetricInterface
             self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN => array(),
         );
         
-        $nodes = $xpath->query("//xhtml:*[contains(@class,'wdn-icon-')]");
+        $nodes = $xpath->query("//xhtml:*[@id='maincontent']//xhtml:*[contains(@class,'wdn-icon-')]");
 
         foreach ($nodes as $node) {
             //perform tests

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -17,6 +17,8 @@ class Metric extends MetricInterface
     const MARK_MN_UNL_FRAMEWORK_YOUTUBUE = 'UNL_FRAMEWORK_YOUTUBUE';
     const MARK_MN_UNL_FRAMEWORK_PDF_LINKS = 'UNL_FRAMEWORK_PDF';
     const MARK_MN_UNL_FRAMEWORK_FLASH_OBJECT = 'UNL_FRAMEWORK_FLASH';
+    const MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN = 'UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN';
+    const MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS = 'UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS';
     
     /**
      * @param string $plugin_name
@@ -31,6 +33,8 @@ class Metric extends MetricInterface
                 self::MARK_MN_UNL_FRAMEWORK_YOUTUBUE => 'A Youtube Embed was found',
                 self::MARK_MN_UNL_FRAMEWORK_PDF_LINKS => 'A PDF was found. Please independently ensure PDF accessibility',
                 self::MARK_MN_UNL_FRAMEWORK_FLASH_OBJECT => 'A flash object was found',
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN => 'An icon font was found without aria-hidden="true"',
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS => 'An icon font is applied to an element with contents',
             ),
             'description_text' => array(
                 self::MARK_MN_UNL_FRAMEWORK_HTML => 'The UNLedu framework HTML is out of date',
@@ -38,6 +42,8 @@ class Metric extends MetricInterface
                 self::MARK_MN_UNL_FRAMEWORK_YOUTUBUE => 'It is important to keep in mind that youtube is blocked in some places around the world, including China.  It is a best practice to host video on mediahub.unl.edu, where the video will not be blocked.',
                 self::MARK_MN_UNL_FRAMEWORK_PDF_LINKS => 'Please ensure that the PDF is accessible.',
                 self::MARK_MN_UNL_FRAMEWORK_FLASH_OBJECT => 'The use of flash is discouraged as it does not work on most mobile devices',
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN => 'Screen readers might read icon-fonts and convey an incorrect or confusing meaning. Icon fonts should be hidden from screen readers.',
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS => 'Because icon fonts should be hidden from screen readers with aria-hidden="true", the element containing the icon font and text within it will not be read.',
             ),
             'help_text' => array(
                 self::MARK_MN_UNL_FRAMEWORK_HTML => 'For mirroring instructions, see [Synchronizing the UNLedu Web Framework](http://wdn.unl.edu/synchronizing-unledu-web-framework)',
@@ -45,6 +51,8 @@ class Metric extends MetricInterface
                 self::MARK_MN_UNL_FRAMEWORK_YOUTUBUE => 'Host the video from [Mediahub](http://mediahub.unl.edu/)',
                 self::MARK_MN_UNL_FRAMEWORK_PDF_LINKS => 'See [webaim](http://webaim.org/techniques/acrobat/) for help with PDF accessibility.',
                 self::MARK_MN_UNL_FRAMEWORK_FLASH_OBJECT => 'Either remove the flash object, or replace it with an HTML5 alternative.',
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN => 'See [the WDN icon-font documentation](http://wdn.unl.edu/documentation/icons) for help with accessibility.',
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS => 'See [the WDN icon-font documentation](http://wdn.unl.edu/documentation/icons) for help with accessibility.',
             ),
             'point_deductions' => array(
                 self::MARK_MN_UNL_FRAMEWORK_HTML => 80,
@@ -52,6 +60,8 @@ class Metric extends MetricInterface
                 self::MARK_MN_UNL_FRAMEWORK_YOUTUBUE => 0,
                 self::MARK_MN_UNL_FRAMEWORK_PDF_LINKS => 0,
                 self::MARK_MN_UNL_FRAMEWORK_FLASH_OBJECT => 0,
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN => 1,
+                self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS => 1,
             )
         ), $options);
 
@@ -234,6 +244,24 @@ class Metric extends MetricInterface
                 $page->addMark($mark, array(
                     'value_found' => $flash_object['value_found'],
                     'context'     => $flash_object['context']
+                ));
+            }
+        }
+
+        $errors = $this->getIconFontErrors($xpath);
+        foreach ($errors as $machine_name=>$elements) {
+            $mark = $this->getMark(
+                $machine_name,
+                $this->getMarkTitle($machine_name),
+                $this->getMarkPointDeduction($machine_name),
+                $this->getMarkDescription($machine_name),
+                $this->getMarkHelpText($machine_name)
+            );
+
+            foreach ($elements as $element) {
+                $page->addMark($mark, array(
+                    'value_found' => $element['value_found'],
+                    'context'     => $element['context']
                 ));
             }
         }
@@ -482,5 +510,53 @@ class Metric extends MetricInterface
         }
 
         return $objects;
+    }
+
+    /**
+     * Get a list of flash objects
+     *
+     * @param \DomXpath $xpath
+     * @return array - an array of objects.  Each link is an associative array with 'file' and 'html' values
+     */
+    public function getIconFontErrors(\DomXpath $xpath)
+    {
+        $errors = array(
+            self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS => array(),
+            self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN => array(),
+        );
+        
+        $nodes = $xpath->query("//xhtml:*[contains(@class,'wdn-icon-')]");
+
+        foreach ($nodes as $node) {
+            //perform tests
+            $node_value = preg_replace('/\s+/', '', $node->nodeValue);
+            $context = htmlspecialchars($xpath->document->saveHTML($node));
+            
+            //compute the value_found (icon class)
+            $icon_class = '';
+            $classes = explode(' ', $node->getAttribute('class'));
+            foreach ($classes as $class) {
+                if (0 === strpos($class, 'wdn-icon-')) {
+                    $icon_class = $class;
+                }
+            }
+            
+            if (!empty($node_value)) {
+                $errors[self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS][] = array(
+                    'value_found' => $icon_class,
+                    'context' => $context,
+                );
+            }
+            
+            
+            if (!$node->hasAttribute('aria-hidden') || 'true' != $node->getAttribute('aria-hidden')) {
+                $errors[self::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN][] = array(
+                    'value_found' => $icon_class,
+                    'context' => $context,
+                );
+            }
+        }
+
+        return $errors;
     }
 }

--- a/tests/MetricTest.php
+++ b/tests/MetricTest.php
@@ -2,7 +2,6 @@
 namespace SiteMaster\Plugins\Unl;
 
 use SiteMaster\Core\Auditor\Parser\HTML5;
-use \SiteMaster\Plugins\Unl\Metric as UNLMetric;
 
 class MetricTest extends \PHPUnit_Framework_TestCase
 {
@@ -106,12 +105,12 @@ class MetricTest extends \PHPUnit_Framework_TestCase
         $errors = $metric->getIconFontErrors($xpath_template);
         
         //Should only have found 1 element for both errors
-        $this->assertEquals(1, count($errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN]));
-        $this->assertEquals(1, count($errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS]));
+        $this->assertEquals(1, count($errors[Metric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN]));
+        $this->assertEquals(1, count($errors[Metric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS]));
         
         //Make sure we found the right elements
-        $this->assertEquals('wdn-icon-no-aria-hidden', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN][0]['value_found']);
-        $this->assertEquals('wdn-icon-has-contents', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS][0]['value_found']);
+        $this->assertEquals('wdn-icon-no-aria-hidden', $errors[Metric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN][0]['value_found']);
+        $this->assertEquals('wdn-icon-has-contents', $errors[Metric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS][0]['value_found']);
     }
 
     public function getTestXPath($filename)

--- a/tests/MetricTest.php
+++ b/tests/MetricTest.php
@@ -2,6 +2,7 @@
 namespace SiteMaster\Plugins\Unl;
 
 use SiteMaster\Core\Auditor\Parser\HTML5;
+use \SiteMaster\Plugins\Unl\Metric as UNLMetric;
 
 class MetricTest extends \PHPUnit_Framework_TestCase
 {
@@ -92,6 +93,25 @@ class MetricTest extends \PHPUnit_Framework_TestCase
         $xpath_template = $this->getTestXPath('example.html');
         $links = $metric->getFlashObjects($xpath_template);
         $this->assertEquals('your-flash-file.swf', $links[0]['value_found']);
+    }
+
+    /**
+     * @test
+     */
+    public function getIconFontErrors()
+    {
+        $metric = new Metric('unl');
+
+        $xpath_template = $this->getTestXPath('icon-font.html');
+        $errors = $metric->getIconFontErrors($xpath_template);
+        
+        //Should only have found 1 element for both errors
+        $this->assertEquals(1, count($errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN]));
+        $this->assertEquals(1, count($errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS]));
+        
+        //Make sure we found the right elements
+        $this->assertEquals('no-aria-hidden', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN][0]->getAttribute('id'));
+        $this->assertEquals('has-contents', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS][0]->getAttribute('id'));
     }
 
     public function getTestXPath($filename)

--- a/tests/MetricTest.php
+++ b/tests/MetricTest.php
@@ -110,8 +110,8 @@ class MetricTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS]));
         
         //Make sure we found the right elements
-        $this->assertEquals('no-aria-hidden', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN][0]->getAttribute('id'));
-        $this->assertEquals('has-contents', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS][0]->getAttribute('id'));
+        $this->assertEquals('wdn-icon-no-aria-hidden', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_NOT_ARIA_HIDDEN][0]['value_found']);
+        $this->assertEquals('wdn-icon-has-contents', $errors[UNLMetric::MARK_MN_UNL_FRAMEWORK_ICON_FONT_HAS_CONTENTS][0]['value_found']);
     }
 
     public function getTestXPath($filename)

--- a/tests/data/icon-font.html
+++ b/tests/data/icon-font.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <title>SiteMaster testing site</title>
+</head>
+<body>
+    <div>
+        This file will test wdn-icon- font detection and usage for a11y considerations
+        
+        <div>
+            Test for missing aria-hidden.
+            <span class="wdn-icon-test" id="no-aria-hidden"></span>
+        </div>
+
+        <div>
+            Test for usage with aria-hidden but the element has content. This can be issue because important text will be hidden from screen readers.
+            <span class="wdn-icon-test" aria-hidden="true" id="has-contents">test contents</span>
+        </div>
+        
+        <div>
+            Good usage
+            <span class="wdn-icon-test" aria-hidden="true" id="good-usage"></span><span class="wdn-text-hidden">test action</span>
+        </div>
+        
+    </div>
+</body>
+</html>

--- a/tests/data/icon-font.html
+++ b/tests/data/icon-font.html
@@ -4,22 +4,22 @@
     <title>SiteMaster testing site</title>
 </head>
 <body>
-    <div>
+    <div id="maincontent">
         This file will test wdn-icon- font detection and usage for a11y considerations
         
         <div>
             Test for missing aria-hidden.
-            <span class="wdn-icon-test" id="no-aria-hidden"></span>
+            <span class="wdn-icon-no-aria-hidden" id="no-aria-hidden"></span>
         </div>
 
         <div>
             Test for usage with aria-hidden but the element has content. This can be issue because important text will be hidden from screen readers.
-            <span class="wdn-icon-test" aria-hidden="true" id="has-contents">test contents</span>
+            <span class="wdn-icon-has-contents" aria-hidden="true" id="has-contents">test contents</span>
         </div>
         
         <div>
             Good usage
-            <span class="wdn-icon-test" aria-hidden="true" id="good-usage"></span><span class="wdn-text-hidden">test action</span>
+            <span class="wdn-icon-good" aria-hidden="true" id="good-usage"></span><span class="wdn-text-hidden">test action</span>
         </div>
         
     </div>


### PR DESCRIPTION
This does the following:

- Enforces `aria-hidden="true"` on `wdn-icon-*` classes
- Enforces the concept that elements which have `wdn-icon-*` classes should have no content (because they will be hidden from screen readers)
- Links to our documentation for more information

I'd like it if we could enforce the use of alternative text, however I can't think of a way to programmatically detect that with any sort of reliability. Alt text might be hidden or shown to sighted users and it might be close to or distant from the icon node. We could start requiring some sort of relationship such as "aria-describedby" (not sure if that is even the best option), but it is a little late in the game make that a requirement. If this continues to be an issue, we could look into that further.