### PR TITLE
Update valid version to 5.3

### DIFF
--- a/src/Progress/Summary.php
+++ b/src/Progress/Summary.php
@@ -93,7 +93,7 @@ class Summary
      */
     public function versionIsValid($version)
     {
-        if (version_compare($version, 5.2, '>=')) {
+        if (version_compare($version, 5.3, '>=')) {
             return true;
         }
 


### PR DESCRIPTION
Hold until Gov Board sets the time that people have to update to be in compliance with 5.3. Allows 5.2+ currently.