### PR TITLE
CMS Site ID storage and display

### DIFF
--- a/data/database.sql
+++ b/data/database.sql
@@ -64,10 +64,11 @@ CREATE TABLE IF NOT EXISTS `unl_version_history` (
 ) ENGINE = InnoDB;
 
 CREATE TABLE IF NOT EXISTS `unl_cms_id` (
+  `id` INT NOT NULL AUTO_INCREMENT,
   `site_id` INT NOT NULL,
   `unlcms_site_id` VARCHAR(20),
   `next_gen_cms_site_id` VARCHAR(20),
-  PRIMARY KEY (`site_id`),
+  PRIMARY KEY (`id`),
   FOREIGN KEY (`site_id`)
   references `sites`(`id`),
 ) ENGINE = InnoDB;

--- a/data/database.sql
+++ b/data/database.sql
@@ -62,3 +62,12 @@ CREATE TABLE IF NOT EXISTS `unl_version_history` (
   PRIMARY KEY  (`id`),
   UNIQUE (`date_created`, `version_type`, `version_number`)
 ) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `unl_cms_id` (
+  `site_id` INT NOT NULL,
+  `unlcms_site_id` VARCHAR(20),
+  `next_gen_cms_site_id` VARCHAR(20),
+  PRIMARY KEY (`site_id`),
+  FOREIGN KEY (`site_id`)
+  references `sites`(`id`),
+) ENGINE = InnoDB;

--- a/data/update-2023092701.sql
+++ b/data/update-2023092701.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `unl_cms_id` (
+  `site_id` INT NOT NULL,
+  `unlcms_site_id` VARCHAR(20),
+  `next_gen_cms_site_id` VARCHAR(20),
+  PRIMARY KEY (`site_id`),
+  FOREIGN KEY (`site_id`)
+  references `sites`(`id`)
+) ENGINE = InnoDB;

--- a/data/update-2023092701.sql
+++ b/data/update-2023092701.sql
@@ -1,8 +1,9 @@
 CREATE TABLE IF NOT EXISTS `unl_cms_id` (
+  `id` INT NOT NULL AUTO_INCREMENT,
   `site_id` INT NOT NULL,
   `unlcms_site_id` VARCHAR(20),
   `next_gen_cms_site_id` VARCHAR(20),
-  PRIMARY KEY (`site_id`),
+  PRIMARY KEY (`id`),
   FOREIGN KEY (`site_id`)
   references `sites`(`id`)
 ) ENGINE = InnoDB;

--- a/scripts/syncUNLCMSSites.php
+++ b/scripts/syncUNLCMSSites.php
@@ -1,4 +1,7 @@
 <?php
+
+use SiteMaster\Plugins\Unl\CMSID;
+
 ini_set('display_errors', true);
 
 //Initialize all settings and autoloaders
@@ -96,6 +99,14 @@ foreach ($cms_sites as $cms_site_id=>$site_info) {
     $site->production_status = determine_production_status($site->base_url);
     $site->base_url = $site_info['uri']; //Base URL protocol might change
     $site->save();
+
+    $cms_id_tracker = CMSID::getBySiteId($site->id);
+    if ($cms_id_tracker === false) {
+        CMSID::createCMSID($site->id, $cms_site_id, null);
+    } else {
+        $cms_id_tracker->unlcms_site_id = $cms_site_id;
+        $cms_id_tracker->save();
+    }
     
     //Add members
     foreach ($site_info['users'] as $uid=>$user_info) {

--- a/src/CMSID.php
+++ b/src/CMSID.php
@@ -1,0 +1,58 @@
+<?php
+namespace SiteMaster\Plugins\Unl;
+
+use DB\Record;
+
+class CMSID extends Record
+{
+    public $site_id;               //int required
+    public $unlcms_site_id;        //VARCHAR(20)
+    public $next_gen_cms_site_id; //VARCHAR(20)
+
+    public function keys()
+    {
+        return array('site_id');
+    }
+
+    public static function getTable()
+    {
+        return 'unl_cms_id';
+    }
+
+    /**
+     * Get CMS id by the sitemaster site id
+     *
+     * @param int $site_id the sitemaster site id
+     * @return bool|CMSID
+     */
+    public static function getBySiteId($site_id)
+    {
+        return self::getByAnyField(__CLASS__, 'site_id', $site_id);
+    }
+
+    
+    /**
+     * Create a new CMS ID entry
+     *
+     * @param int $site_id site_id of the sitemaster site
+     * @param string $unlcms_site_id unlcms site id
+     * @param string $next_gen_cms_site_id next-gen cms site id
+     * @param array $fields an associative array of field names and values to insert
+     * @return bool|CMSID
+     */
+    public static function createCMSID($site_id, $unlcms_site_id, $next_gen_cms_site_id, array $fields = array())
+    {
+        $link = new self();
+        $link->synchronizeWithArray($fields);
+
+        $link->site_id = $site_id;
+        $link->unlcms_site_id = $unlcms_site_id;
+        $link->next_gen_cms_site_id = $next_gen_cms_site_id;
+
+        if (!$link->insert()) {
+            return false;
+        }
+
+        return $link;
+    }
+}

--- a/src/CMSID.php
+++ b/src/CMSID.php
@@ -5,13 +5,14 @@ use DB\Record;
 
 class CMSID extends Record
 {
+    public $id;               //int required
     public $site_id;               //int required
     public $unlcms_site_id;        //VARCHAR(20)
     public $next_gen_cms_site_id; //VARCHAR(20)
 
     public function keys()
     {
-        return array('site_id');
+        return array('id');
     }
 
     public static function getTable()

--- a/src/CMSID/All.php
+++ b/src/CMSID/All.php
@@ -1,0 +1,36 @@
+<?php
+namespace SiteMaster\Plugins\Unl\CMSID;
+
+use DB\RecordList;
+
+class All extends RecordList
+{
+    public function __construct(array $options = array())
+    {
+        $this->options = $options + $this->options;
+
+        $options['array'] = self::getBySQL(array(
+            'sql'         => $this->getSQL(),
+            'returnArray' => true
+        ));
+
+        parent::__construct($options);
+    }
+
+    public function getDefaultOptions()
+    {
+        $options = array();
+        $options['itemClass'] = '\SiteMaster\Plugins\Unl\CMSID';
+        $options['listClass'] = __CLASS__;
+
+        return $options;
+    }
+
+    public function getSQL()
+    {
+        //Build the list
+        $sql = "SELECT id FROM unl_cms_id";
+
+        return $sql;
+    }
+}

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -21,6 +21,7 @@ class Listener extends PluginListener
         $event->addRoute('/^unl_progress\/help\/$/', __NAMESPACE__ . '\Help\VersionProgress');
         $event->addRoute('/^unl_versions\/$/', __NAMESPACE__ . '\VersionReport');
         $event->addRoute('/^sites\/(?P<site_id>(\d*))\/scans\/(?P<scans_id>(\d*))\/unl\/versions\/$/',     __NAMESPACE__ . '\Scan\FrameworkVersions');
+        $event->addRoute('/^unl_ownership_report\/$/', __NAMESPACE__ . '\OwnershipReport');
     }
 
     /**

--- a/src/OwnershipReport.php
+++ b/src/OwnershipReport.php
@@ -1,0 +1,40 @@
+<?php
+namespace SiteMaster\Plugins\Unl;
+
+use SiteMaster\Plugins\Unl\CMSID\All as CMSID_All;
+use SiteMaster\Core\Registry\Site\Members\All as Members_All;
+
+use SiteMaster\Core\ViewableInterface;
+
+class OwnershipReport implements ViewableInterface
+{
+    /**
+     * @var array
+     */
+    public $options = array();
+
+    public $sites = array();
+
+    // This page is for displaying all CMS sites along with their ownership/management
+    function __construct($options = array())
+    {
+        $this->options += $options;
+
+        $this->sites = new CMSID_All();
+    }
+
+    public function getURL()
+    {
+        return \SiteMaster\Core\Config::get('URL') . 'unl_site_ownership/';
+    }
+
+    public function getPageTitle()
+    {
+        return 'Ownership Report';
+    }
+
+    public function getMembers($site_id)
+    {
+        return new Members_All(array('site_id' => $site_id));
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,6 +10,8 @@ use SiteMaster\Core\Events\RoutesCompile;
 use SiteMaster\Core\Events\Theme\PrependOutput;
 use SiteMaster\Core\Events\Theme\RegisterStyleSheets;
 use SiteMaster\Core\Util;
+use SiteMaster\Core\Registry\Site\Role;
+
 
 class Plugin extends PluginInterface
 {
@@ -42,6 +44,7 @@ class Plugin extends PluginInterface
                 drop table if exists unl_scan_attributes;
                 drop table if exists unl_page_attributes;
                 drop table if exists unl_site_progress;
+                drop table if exists unl_cms_id;
                 SET FOREIGN_KEY_CHECKS = 1";
 
         if (!Util::execMultiQuery($sql, true)) {
@@ -98,6 +101,14 @@ class Plugin extends PluginInterface
                 return false;
             }
         }
+
+        if ($previousVersion <= 2015010701) {
+            $sql = file_get_contents($this->getRootDirectory() . "/data/update-2023092701.sql");
+
+            if (!Util::execMultiQuery($sql, true)) {
+                return false;
+            }
+        }
         
         return true;
     }
@@ -113,7 +124,7 @@ class Plugin extends PluginInterface
      */
     public function getVersion()
     {
-        return 2015010701;
+        return 2023092701;
     }
 
     /**

--- a/www/templates/html/OwnershipReport.tpl.php
+++ b/www/templates/html/OwnershipReport.tpl.php
@@ -1,4 +1,4 @@
-<p>This page provides a list of UNL CMS websites and their Owner, Primary Site Manager, and Backup Site Manager.</p>
+<p>This page provides a list of UNL CMS websites and their Owner, Primary Site Manager, and Secondary Site Manager.</p>
 
 <table>
     <tr>
@@ -6,16 +6,16 @@
         <th>UNL CMS id</th>
         <th>Owner</th>
         <th>Primary Site Manager</th>
-        <th>Backup Site Manager</th>
+        <th>Secondary Site Manager</th>
     </tr>
     <?php foreach ($context->sites as $site): ?>
         <?php
             $owner = "";
             $primary_site_manager = "";
-            $backup_site_manager = "";
+            $secondary_site_manager = "";
             $site_members = $context->getMembers($site->site_id);
 
-            // Get the owner, primary site manager, backup site manager from the list of members
+            // Get the owner, primary site manager, Secondary site manager from the list of members
             foreach ($site_members as $member) {
                 $member_roles = $member->getRoles();
                 $user = $member->getUser();
@@ -24,8 +24,8 @@
                     if ($role_name === 'Owner') {
                         $owner = $user->uid;
                     }
-                    if ($role_name === 'Backup Site Manager') {
-                        $backup_site_manager = $user->uid;
+                    if ($role_name === 'Secondary Site Manager') {
+                        $secondary_site_manager = $user->uid;
                     }
                     if ($role_name === 'Primary Site Manager') {
                         $primary_site_manager = $user->uid;
@@ -38,7 +38,7 @@
             <td><?php echo $site->unlcms_site_id; ?></td>
             <td><?php echo $owner; ?></td>
             <td><?php echo $primary_site_manager; ?></td>
-            <td><?php echo $backup_site_manager; ?></td>
+            <td><?php echo $secondary_site_manager; ?></td>
         </tr>
     <?php endforeach; ?>
 </table>

--- a/www/templates/html/OwnershipReport.tpl.php
+++ b/www/templates/html/OwnershipReport.tpl.php
@@ -13,7 +13,7 @@
             $owner = "";
             $primary_site_manager = "";
             $backup_site_manager = "";
-            $site_members = $context->getMembers($site->id);
+            $site_members = $context->getMembers($site->site_id);
 
             // Get the owner, primary site manager, backup site manager from the list of members
             foreach ($site_members as $member) {
@@ -22,13 +22,13 @@
                 foreach ($member_roles as $role) {
                     $role_name = $role->getRole()->role_name;
                     if ($role_name === 'Owner') {
-                        $owner = $user->first_name . ' ' .  $user->last_name;
+                        $owner = $user->uid;
                     }
                     if ($role_name === 'Backup Site Manager') {
-                        $backup_site_manager = $user->first_name . ' ' .  $user->last_name;
+                        $backup_site_manager = $user->uid;
                     }
                     if ($role_name === 'Primary Site Manager') {
-                        $primary_site_manager = $user->first_name . ' ' .  $user->last_name;
+                        $primary_site_manager = $user->uid;
                     }
                 }
             }

--- a/www/templates/html/OwnershipReport.tpl.php
+++ b/www/templates/html/OwnershipReport.tpl.php
@@ -1,0 +1,44 @@
+<p>This page provides a list of UNL CMS websites and their Owner, Primary Site Manager, and Backup Site Manager.</p>
+
+<table>
+    <tr>
+        <th>Webaudit id</th>
+        <th>UNL CMS id</th>
+        <th>Owner</th>
+        <th>Primary Site Manager</th>
+        <th>Backup Site Manager</th>
+    </tr>
+    <?php foreach ($context->sites as $site): ?>
+        <?php
+            $owner = "";
+            $primary_site_manager = "";
+            $backup_site_manager = "";
+            $site_members = $context->getMembers($site->id);
+
+            // Get the owner, primary site manager, backup site manager from the list of members
+            foreach ($site_members as $member) {
+                $member_roles = $member->getRoles();
+                $user = $member->getUser();
+                foreach ($member_roles as $role) {
+                    $role_name = $role->getRole()->role_name;
+                    if ($role_name === 'Owner') {
+                        $owner = $user->uid;
+                    }
+                    if ($role_name === 'Backup Site Manager') {
+                        $backup_site_manager = $user->uid;
+                    }
+                    if ($role_name === 'Primary Site Manager') {
+                        $primary_site_manager = $user->uid;
+                    }
+                }
+            }
+        ?>
+        <tr>
+            <td><?php echo $site->site_id; ?></td>
+            <td><?php echo $site->unlcms_site_id; ?></td>
+            <td><?php echo $owner; ?></td>
+            <td><?php echo $primary_site_manager; ?></td>
+            <td><?php echo $backup_site_manager; ?></td>
+        </tr>
+    <?php endforeach; ?>
+</table>

--- a/www/templates/html/OwnershipReport.tpl.php
+++ b/www/templates/html/OwnershipReport.tpl.php
@@ -22,13 +22,13 @@
                 foreach ($member_roles as $role) {
                     $role_name = $role->getRole()->role_name;
                     if ($role_name === 'Owner') {
-                        $owner = $user->uid;
+                        $owner = $user->first_name . ' ' .  $user->last_name;
                     }
                     if ($role_name === 'Backup Site Manager') {
-                        $backup_site_manager = $user->uid;
+                        $backup_site_manager = $user->first_name . ' ' .  $user->last_name;
                     }
                     if ($role_name === 'Primary Site Manager') {
-                        $primary_site_manager = $user->uid;
+                        $primary_site_manager = $user->first_name . ' ' .  $user->last_name;
                     }
                 }
             }

--- a/www/templates/json/OwnershipReport.tpl.php
+++ b/www/templates/json/OwnershipReport.tpl.php
@@ -1,0 +1,37 @@
+<?php 
+$sites_output = array();
+foreach ($context->sites as $site){
+    $owner = "";
+    $primary_site_manager = "";
+    $backup_site_manager = "";
+    $site_members = $context->getMembers($site->id);
+
+    // Get the owner, primary site manager, backup site manager from the list of members
+    foreach ($site_members as $member) {
+        $member_roles = $member->getRoles();
+        $user = $member->getUser();
+        foreach ($member_roles as $role) {
+            $role_name = $role->getRole()->role_name;
+            if ($role_name === 'Owner') {
+                $owner = $user->uid;
+            }
+            if ($role_name === 'Backup Site Manager') {
+                $backup_site_manager = $user->uid;
+            }
+            if ($role_name === 'Primary Site Manager') {
+                $primary_site_manager = $user->uid;
+            }
+        }
+    }
+
+    $sites_output[] = array(
+        'webaudit_site_id' => $site->site_id,
+        'unlcms_site_id' => isset($site->unlcms_site_id) ? $site->unlcms_site_id : null,
+        'owner' => !empty($owner) ? $owner : null,
+        'backup_site_manager' => !empty($backup_site_manager) ? $backup_site_manager : null,
+        'primary_site_manager' => !empty($primary_site_manager) ? $primary_site_manager : null,
+    );
+}
+
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode($sites_output, JSON_PRETTY_PRINT);

--- a/www/templates/json/OwnershipReport.tpl.php
+++ b/www/templates/json/OwnershipReport.tpl.php
@@ -3,10 +3,10 @@ $sites_output = array();
 foreach ($context->sites as $site){
     $owner = "";
     $primary_site_manager = "";
-    $backup_site_manager = "";
+    $secondary_site_manager = "";
     $site_members = $context->getMembers($site->id);
 
-    // Get the owner, primary site manager, backup site manager from the list of members
+    // Get the owner, primary site manager, Secondary site manager from the list of members
     foreach ($site_members as $member) {
         $member_roles = $member->getRoles();
         $user = $member->getUser();
@@ -15,8 +15,8 @@ foreach ($context->sites as $site){
             if ($role_name === 'Owner') {
                 $owner = $user->uid;
             }
-            if ($role_name === 'Backup Site Manager') {
-                $backup_site_manager = $user->uid;
+            if ($role_name === 'Secondary Site Manager') {
+                $secondary_site_manager = $user->uid;
             }
             if ($role_name === 'Primary Site Manager') {
                 $primary_site_manager = $user->uid;
@@ -28,8 +28,8 @@ foreach ($context->sites as $site){
         'webaudit_site_id' => $site->site_id,
         'unlcms_site_id' => isset($site->unlcms_site_id) ? $site->unlcms_site_id : null,
         'owner' => !empty($owner) ? $owner : null,
-        'backup_site_manager' => !empty($backup_site_manager) ? $backup_site_manager : null,
         'primary_site_manager' => !empty($primary_site_manager) ? $primary_site_manager : null,
+        'secondary_site_manager' => !empty($secondary_site_manager) ? $secondary_site_manager : null,
     );
 }
 


### PR DESCRIPTION
Store the CMS site ID during sync and provide ownership report page.

This goes along with [Sitemaster#196](https://github.com/UNLSiteMaster/site_master/pull/196)