### PR TITLE
Fixed foreign key constraint

### DIFF
--- a/data/database.sql
+++ b/data/database.sql
@@ -70,5 +70,7 @@ CREATE TABLE IF NOT EXISTS `unl_cms_id` (
   `next_gen_cms_site_id` VARCHAR(20),
   PRIMARY KEY (`id`),
   FOREIGN KEY (`site_id`)
-  references `sites`(`id`),
+  REFERENCES `sites` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION,
 ) ENGINE = InnoDB;

--- a/data/update-2023092701.sql
+++ b/data/update-2023092701.sql
@@ -5,5 +5,7 @@ CREATE TABLE IF NOT EXISTS `unl_cms_id` (
   `next_gen_cms_site_id` VARCHAR(20),
   PRIMARY KEY (`id`),
   FOREIGN KEY (`site_id`)
-  references `sites`(`id`)
+  REFERENCES `sites` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION,
 ) ENGINE = InnoDB;


### PR DESCRIPTION
There was an error when trying to delete a site since the foreign key was not set up properly on the `unl_cms_id` table